### PR TITLE
fix for Uncaught ReferenceError: p is not definer when expanding groups

### DIFF
--- a/dist/jsgrid-0.1.0.js
+++ b/dist/jsgrid-0.1.0.js
@@ -9971,9 +9971,9 @@ $.jgrid.extend({
 							break;// next grouping header of the same lever are found
 						}
 						if (itemGroupingLevel === num + 1) {
-							$(r).show().find(">td>span."+"tree-wrap-"+p.direction).removeClass(minus).addClass(plus);
+							$(r).show().find(">td>span."+"tree-wrap-"+$t.p.direction).removeClass(minus).addClass(plus);
 							if(frz) {
-								$(r2).show().find(">td>span."+"tree-wrap-"+p.direction).removeClass(minus).addClass(plus);
+								$(r2).show().find(">td>span."+"tree-wrap-"+$t.p.direction).removeClass(minus).addClass(plus);
 							}
 						}
 					} else if (showData) {


### PR DESCRIPTION
In reference to issue #86 

Now that I have had a chance to test this out, I see that the issue has been resolved but now there is a new bug which doesn't allow an expanded group to close and reopen without throwing an error in the console: Uncaught ReferenceError: p is not defined. This push request fixed that error.