### PR TITLE
Updating dependency installation to use package-script to handle the global stuff

### DIFF
--- a/installDependencies.js
+++ b/installDependencies.js
@@ -1,0 +1,11 @@
+require('package-script').spawn([
+      {
+          command: "npm",
+          args: ["install", "-g", "grunt-cli"]
+      },
+      {
+          command: "npm",
+          args: ["install", "-g", "bower"]
+      }
+
+  ]);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "preinstall": "npm i -g bower"
+    "install": "node installDependencies.js"
   },
   "devDependencies": {
     "assemble": "^0.4.42",
@@ -28,6 +28,7 @@
     "grunt-karma": "^0.9.0",
     "karma-firefox-launcher": "^0.1.4",
     "karma-qunit": "^0.1.4",
-    "qunitjs": "^1.16.0"
+    "qunitjs": "^1.16.0",
+	"package-script":  "^0.0.8"
   }
 }


### PR DESCRIPTION
I found when trying to the install commands out on my Mac that the old approach didn't work. This should still enable it to work as you'd expect on Windows, and it should work on Mac too - but it is worth checking that it works on a Mac/Linux without Node installed before accepting the pull.